### PR TITLE
Extend HttpConnection to allow for db specification

### DIFF
--- a/src/ClickHouseDriver/Core/HTTP/Client.hs
+++ b/src/ClickHouseDriver/Core/HTTP/Client.hs
@@ -121,7 +121,7 @@ fetchData settings fetches = do
         BlockedFetch Ping var' -> ("ping", var')
   e <- Control.Exception.try $ do
     case settings of
-      HttpConnection _ _ _ _ mng -> do
+      HttpConnection _ _ _ _ mng Nothing -> do
         url <- genURL settings queryWithType
         req <- parseRequest url
         ans <- responseBody <$> httpLbs req mng
@@ -152,7 +152,7 @@ getJsonM = mapM getJSON
 exec :: String->Env HttpConnection w->IO (Either C8.ByteString String)
 exec cmd' env = do
   let cmd = C8.pack cmd'
-  let settings@(HttpConnection _ _ _ _ mng) = userEnv env
+  let settings@(HttpConnection _ _ _ _ mng Nothing) = userEnv env
   url <- genURL settings ""
   req <- parseRequest url
   ans <- responseBody <$> httpLbs req{ method = "POST"
@@ -168,7 +168,7 @@ insertOneRow :: String
 insertOneRow table_name arr environment = do
   let row = toString arr
   let cmd = C8.pack ("INSERT INTO " ++ table_name ++ " VALUES " ++ row)
-  let settings@(HttpConnection _ _ _ _ mng) = userEnv environment
+  let settings@(HttpConnection _ _ _ _ mng Nothing) = userEnv environment
   url <- genURL settings ""
   req <- parseRequest url
   ans <- responseBody <$> httpLbs req{ method = "POST"
@@ -186,7 +186,7 @@ insertMany table_name rows environment = do
       comma =  char8 ','
       preset = lazyByteString $ C8.pack $ "INSERT INTO " <> table_name <> " VALUES "
       togo = preset <> (foldl1 (\x y-> x <> comma <> y) rowsString)
-  let settings@(HttpConnection _ _ _ _ mng) = userEnv environment
+  let settings@(HttpConnection _ _ _ _ mng Nothing) = userEnv environment
   url <- genURL settings ""
   req <- parseRequest url
   ans <- responseBody <$> httpLbs req{method = "POST"
@@ -199,7 +199,7 @@ insertMany table_name rows environment = do
 insertFromFile :: String->Format->FilePath->Env HttpConnection w->IO(Either C8.ByteString String)
 insertFromFile table_name format file environment = do
   fileReqBody <- streamFile file
-  let settings@(HttpConnection _ _ _ _ mng) = userEnv environment
+  let settings@(HttpConnection _ _ _ _ mng Nothing) = userEnv environment
   url <- genURL settings ("INSERT INTO " <> table_name 
     <> case format of
           CSV->" FORMAT CSV"

--- a/src/ClickHouseDriver/Core/HTTP/Connection.hs
+++ b/src/ClickHouseDriver/Core/HTTP/Connection.hs
@@ -4,6 +4,7 @@
 
 module ClickHouseDriver.Core.HTTP.Connection (
     httpConnect,
+    httpConnectDb,
     defaultHttpConnection,
     HttpConnection(..),
 ) where
@@ -21,7 +22,8 @@ data HttpConnection
         httpPort :: {-# UNPACK #-}     !Int,
         httpUsername :: {-# UNPACK #-}  !String,
         httpPassword :: {-# UNPACK #-} !String,
-        httpManager ::  {-# UNPACK #-} !Manager
+        httpManager ::  {-# UNPACK #-} !Manager,
+        httpDatabase :: {-# UNPACK #-} !(Maybe String)
       }
 
 defaultHttpConnection :: IO (HttpConnection)
@@ -29,12 +31,18 @@ defaultHttpConnection = httpConnect DEFAULT_USERNAME DEFAULT_PASSWORD 8123 DEFAU
 
 
 httpConnect :: String->String->Int->String->IO(HttpConnection)
-httpConnect user password port host = do
+httpConnect user password port host = 
+  httpConnectDb user password port host Nothing
+
+
+httpConnectDb :: String->String->Int->String->Maybe String->IO(HttpConnection)
+httpConnectDb user password port host database = do
   mng <- newManager defaultManagerSettings
   return HttpConnection {
     httpHost = host,
     httpPassword = password,
     httpPort = port,
     httpUsername = user,
-    httpManager = mng
+    httpManager = mng,
+    httpDatabase = database
   }

--- a/src/ClickHouseDriver/Core/HTTP/Helpers.hs
+++ b/src/ClickHouseDriver/Core/HTTP/Helpers.hs
@@ -21,6 +21,7 @@ import ClickHouseDriver.IO.BufferedWriter
 import ClickHouseDriver.Core.Column
 import Data.Vector (toList)
 import qualified Network.URI.Encode as NE
+import Data.Maybe
 
 -- | Trim JSON data
 extract :: C8.ByteString -> JSONResult
@@ -43,7 +44,8 @@ genURL HttpConnection {
        httpHost = host,
        httpPassword = pw, 
        httpPort = port, 
-       httpUsername = usr} cmd = do
+       httpUsername = usr,
+       httpDatabase = db} cmd = do
          (_,basicUrl) <- runWriterT $ do
            writeIn "http://"
            writeIn usr
@@ -55,6 +57,7 @@ genURL HttpConnection {
            writeIn $ show port   
            writeIn "/"
            if cmd == "ping" then return () else writeIn "?query="
+           writeIn $ dbUrl db
          let res = basicUrl ++ NE.encode cmd
          return res
 
@@ -73,3 +76,6 @@ toStr' (CKArray arr) = "[" ++ (toStr $ toList arr) ++ "]"
 toStr' (CKTuple arr) = "(" ++ (toStr $ toList arr) ++ ")"
 toStr' CKNull = "null"
 toStr' _ = error "unsupported writing type"
+
+dbUrl :: (Maybe String) -> String
+dbUrl = fromMaybe "" . fmap ("?database=" ++)


### PR DESCRIPTION
Add an optional database for http client through the ["?database="](https://clickhouse.tech/docs/en/interfaces/http/#cli-queries-with-parameters) parameter.